### PR TITLE
add setting to change mysql table prefix

### DIFF
--- a/src/main/java/ca/tweetzy/auctionhouse/AuctionHouse.java
+++ b/src/main/java/ca/tweetzy/auctionhouse/AuctionHouse.java
@@ -168,7 +168,10 @@ public class AuctionHouse extends TweetyPlugin {
 
 		// Setup the database if enabled
 		this.databaseConnector = Settings.DATABASE_USE.getBoolean() ? new MySQLConnector(this, Settings.DATABASE_HOST.getString(), Settings.DATABASE_PORT.getInt(), Settings.DATABASE_NAME.getString(), Settings.DATABASE_USERNAME.getString(), Settings.DATABASE_PASSWORD.getString(), Settings.DATABASE_USE_SSL.getBoolean()) : new SQLiteConnector(this);
-		this.dataManager = new DataManager(this.databaseConnector, this);
+
+		// Use a custom table prefix if using a remote database. The default prefix setting acts exactly like if the prefix is null
+		final String tablePrefix = Settings.DATABASE_USE.getBoolean() ? Settings.DATABASE_TABLE_PREFIX.getString() : null;
+		this.dataManager = new DataManager(this.databaseConnector, this, tablePrefix);
 
 		DataMigrationManager dataMigrationManager = new DataMigrationManager(this.databaseConnector, this.dataManager,
 				new _1_InitialMigration(),

--- a/src/main/java/ca/tweetzy/auctionhouse/commands/CommandUpload.java
+++ b/src/main/java/ca/tweetzy/auctionhouse/commands/CommandUpload.java
@@ -42,7 +42,7 @@ public final class CommandUpload extends AbstractCommand {
 		if (!args[0].equalsIgnoreCase("-confirm")) return ReturnType.FAILURE;
 
 		DatabaseConnector databaseConnector = new SQLiteConnector(AuctionHouse.getInstance());
-		DataManager manager = new DataManager(databaseConnector, AuctionHouse.getInstance());
+		DataManager manager = new DataManager(databaseConnector, AuctionHouse.getInstance(), null);
 
 		manager.getItems((error, items) -> {
 			if (error == null)

--- a/src/main/java/ca/tweetzy/auctionhouse/database/DataManager.java
+++ b/src/main/java/ca/tweetzy/auctionhouse/database/DataManager.java
@@ -39,8 +39,16 @@ public class DataManager extends DataManagerAbstract {
 
 	private final ExecutorService thread = Executors.newSingleThreadExecutor();
 
-	public DataManager(DatabaseConnector databaseConnector, Plugin plugin) {
+	private final @Nullable String customTablePrefix;
+
+	public DataManager(DatabaseConnector databaseConnector, Plugin plugin, @Nullable String customTablePrefix) {
 		super(databaseConnector, plugin);
+		this.customTablePrefix = customTablePrefix;
+	}
+
+	@Override
+	public String getTablePrefix() {
+		return customTablePrefix == null ? super.getTablePrefix() : customTablePrefix;
 	}
 
 	public void close() {

--- a/src/main/java/ca/tweetzy/auctionhouse/settings/Settings.java
+++ b/src/main/java/ca/tweetzy/auctionhouse/settings/Settings.java
@@ -241,6 +241,7 @@ public class Settings {
 	 *         DATABASE OPTIONS
 	 *  ===============================*/
 	public static final ConfigSetting DATABASE_USE = new ConfigSetting(config, "database.use database", false, "Should the plugin use a database to store shop data?");
+	public static final ConfigSetting DATABASE_TABLE_PREFIX = new ConfigSetting(config, "database.table prefix", "auctionhouse_", "What prefix should be used for table names");
 	public static final ConfigSetting DATABASE_HOST = new ConfigSetting(config, "database.host", "localhost", "What is the connection url/host");
 	public static final ConfigSetting DATABASE_PORT = new ConfigSetting(config, "database.port", 3306, "What is the port to database (default is 3306)");
 	public static final ConfigSetting DATABASE_NAME = new ConfigSetting(config, "database.name", "plugin_dev", "What is the name of the database?");


### PR DESCRIPTION
When running the plugin on a network, it's annoying to need several MySQL databases to separate the data. Having a setting to change the table prefix can come in quite handy